### PR TITLE
Fix the failure to exec `/.docker/*.sh`.

### DIFF
--- a/samba4-ad/Dockerfile
+++ b/samba4-ad/Dockerfile
@@ -36,7 +36,7 @@ ENV AD_NOSTRONGAUTH 1
 ENV AD_HOST_IP ""
 ENV AD_OPTIONS ""
 
-VOLUME ["/var/lib/samba", "/var/log/samba", "/etc/samba", "/.docker"]
+VOLUME ["/var/lib/samba", "/var/log/samba", "/etc/samba"]
 
 EXPOSE 53 135 137/udp 138/udp 139 389 445 464 636
 

--- a/samba4-ad/README.md
+++ b/samba4-ad/README.md
@@ -39,7 +39,6 @@ Include sonohara/samba4-base:latest image.
     /var/lib/samba
     /var/log/samba
     /etc/samba
-    /.docker
 
 ## Examples
 


### PR DESCRIPTION
## What is problem?
`/entrypoint.sh: line 9: /.docker/init.sh: Permission denied` occurs on starting container.

```yml
version: '3.2'
services:
  addc:
    image: sonohara/samba4-ad:latest
    restart: always
    environment:
      DOCKER_DEBUG: 1
      DNS_FORWARD: 8.8.8.8
      DNS_DOMAIN: kportal.local
      AD_PASSWORD: P@ssw0rd
      AD_REALM: kportal.local
      AD_DOMAIN: KPORTAL
    ports:
      - "53:53"
      - "135:135"
      - "137:137"
      - "138:138"
      - "139:139"
      - "389:389"
      - "445:445"
      - "464:464"
      - "636:636"
    volumes:
      - ./var/lib/samba:/var/lib/samba
      - ./var/log/samba:/var/log/samba
```

```
$ docker-compose up

k-portal_addc_1 exited with code 126
addc_1     | total 16
addc_1     | -rw-r--r-- 1 root root    0 Nov 19  2017 smb-share.conf
addc_1     | -rw-r--r-- 1 root root   40 Nov 19  2017 smb-global.conf
addc_1     | -rw-r--r-- 1 root root 1167 Nov 19  2017 setup.sh
addc_1     | -rw-r--r-- 1 root root  227 Nov 19  2017 service.sh
addc_1     | -rw-r--r-- 1 root root  272 Nov 19  2017 init.sh
addc_1     | -rw-r--r-- 1 root root    0 Nov 19  2017 config
addc_1     | /entrypoint.sh: line 9: /.docker/init.sh: Permission denied
addc_1     | /entrypoint.sh: line 12: /.docker/setup.sh: Permission denied
addc_1     | /entrypoint.sh: line 15: /.docker/service.sh: Permission denied
```

## Why causes?
`/.docker` directory was `volume`.
Reset permission to `644` after `chmod`.

```Dockerfile
FROM sonohara/samba4-base:latest

RUN chmod 755 /.docker
RUN chmod 755 /.docker/*.sh

VOLUME ["/var/lib/samba", "/var/log/samba", "/etc/samba", "/.docker"]
```

## How to fix?
`/.docker` directory excludes from `VOLUME`.
